### PR TITLE
shift_type- ja shift-taulujen luonti

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Projektin lataaminen ja konfigurointi Windows-käyttöjärjestelmällä
 1. Kloonaa repositorio:
 ```
-git clone https://github.com/inkaliinalauranto/WTT-backend.git
+git clone https://github.com/Anttiom1/WTT-backend.git
 ```
 2. Avaa projekti esim. *Visual Studio Codella*:
 ```

--- a/app/db.py
+++ b/app/db.py
@@ -7,6 +7,9 @@ from sqlalchemy.orm import sessionmaker, Session
 
 DB_USER = os.getenv("MYSQL_USER")
 DB_PASSWORD = os.getenv("MYSQL_PASSWORD")
+# Jotta toimi (Inka-Liinalla), oli MY_SQL_DATABASE-ympäristömuuttujan arvo 
+# vaihdettava "db":ksi:
+# DB_HOST = "db"
 DB_HOST = os.getenv("MYSQL_DATABASE")
 DB_NAME = os.getenv("MYSQL_DATABASE_NAME")
 

--- a/app/models.py
+++ b/app/models.py
@@ -58,3 +58,21 @@ class Organization(Base):
 
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(45), nullable=False, unique=True)
+
+
+class ShifType(Base):
+    __tablename__ = "shift_type"
+
+    id = Column(Integer, primary_key=True, index=True)
+    type = Column(String(45), nullable=False, unique=True)
+
+
+class Shift(Base):
+    __tablename__ = "shift"
+
+    id = Column(Integer, primary_key=True, index=True)
+    start_time = Column(TIMESTAMP, nullable=False)
+    end_time = Column(TIMESTAMP, nullable=True)
+    user_id = Column(Integer, ForeignKey("user.id"))
+    shift_type_id = Column(Integer, ForeignKey("shift_type.id"))
+    description = Column(String(255), nullable=True)

--- a/app/models.py
+++ b/app/models.py
@@ -60,7 +60,7 @@ class Organization(Base):
     name = Column(String(45), nullable=False, unique=True)
 
 
-class ShifType(Base):
+class ShiftType(Base):
     __tablename__ = "shift_type"
 
     id = Column(Integer, primary_key=True, index=True)


### PR DESCRIPTION
Lisätty model.py-tiedostoon ShiftType- ja Shift-classit, jotka luovat vastaavat taulut tietokantaan. db.py-tiedostoon kommentoitu se DB_HOST-muuttujan arvo, joka Inka-Liinalla toimii. Päivitetty README.md repon omistajuusvaihdoksen mukaisiin tietoihin.